### PR TITLE
Update version num to make previous changes publishable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goldenagellc/web3-blocks",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Higher level building blocks to improve QoL when working with web3.js",
   "author": "Hayden Shively",
   "license": "None",


### PR DESCRIPTION
I accidentally pushed directly to main branch since I had branch protection rules turned off. Then I realized I forgot to increment the version number in order to publish a new package version. So now branch protection rules are on and you get to review the smallest change ever